### PR TITLE
Remove Steam Workshop dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ A mod for the Cities: Skylines game. Adjusts the time flow in the game to make i
 **Real Time** works best with medium-sized cities (population up to 65.500). With large cities, there are some game limitations that make it difficult for **Real Time** to keep the citizens behavior realistic. Furthermore, the CPU usage and the graphic adapter load increase drastically, because every citizen needs to be precisely simulated.
 
 ## Distribution
-**Real Time** is published on Steam Workshop. To use **Real Time**, players need to subscribe to [this Steam Workshop item](https://steamcommunity.com/sharedfiles/filedetails/?id=1420955187).
+**Real Time** is published on Steam Workshop. To use **Real Time**, players may subscribe to [this Steam Workshop item](https://steamcommunity.com/sharedfiles/filedetails/?id=1420955187).

--- a/src/RealTime/Core/RealTimeMod.cs
+++ b/src/RealTime/Core/RealTimeMod.cs
@@ -18,8 +18,7 @@ namespace RealTime.Core
     /// <summary>The main class of the Real Time mod.</summary>
     public sealed class RealTimeMod : LoadingExtensionBase, IUserMod
     {
-        private const long WorkshopId = 1420955187;
-        private const string NoWorkshopMessage = "Real Time can only run when subscribed to in Steam Workshop";
+        private const string NoWorkshopMessage = "Real Time cannot find its path";
 
         private readonly string modVersion = GitVersion.GetAssemblyVersion(typeof(RealTimeMod).Assembly);
         private readonly string modPath = GetModPath();
@@ -180,7 +179,7 @@ namespace RealTime.Core
         private static string GetModPath()
         {
             PluginManager.PluginInfo pluginInfo = PluginManager.instance.GetPluginsInfo()
-                .FirstOrDefault(pi => pi.publishedFileID.AsUInt64 == WorkshopId);
+                .FirstOrDefault(pi => pi.ContainsAssembly(System.Reflection.Assembly.GetExecutingAssembly()));
 
             return pluginInfo?.modPath;
         }


### PR DESCRIPTION
I believe the only reason for depending on the Steam Workshop subscription was to be able to find the directory containing the mod so that the Events' XML files could be loaded. I found another, possibly more robust way to figure out the module's path (using a check with `GetExecutingAssembly()`), so that the Steam Workshop item subscription is no longer required.

Fixes https://github.com/dymanoid/RealTime/issues/159.

Thank you for this great mod!