### PR TITLE
Add compatibility checks for new 'Revisited' mods

### DIFF
--- a/src/RealTime/Core/RealTimeCore.cs
+++ b/src/RealTime/Core/RealTimeCore.cs
@@ -326,9 +326,9 @@ namespace RealTime.Core
                 OutsideConnectionAIPatch.DummyTrafficProbability,
             };
 
-            if (compatibility.IsAnyModActive(WorkshopMods.CitizenLifecycleRebalance))
+            if (compatibility.IsAnyModActive(WorkshopMods.CitizenLifecycleRebalance) || compatibility.IsAnyModActive(WorkshopMods.LifecycleRebalanceRevisited))
             {
-                Log.Info("The 'Real Time' mod will not change the citizens aging because the 'Citizen Lifecycle Rebalance' mod is active.");
+                Log.Info("The 'Real Time' mod will not change the citizens aging because a 'Lifecycle Rebalance' mod is active.");
             }
             else
             {
@@ -343,6 +343,7 @@ namespace RealTime.Core
                 WorkshopMods.ForceLevelUp,
                 WorkshopMods.PloppableRico,
                 WorkshopMods.PloppableRicoHighDensityFix,
+                WorkshopMods.PloppableRICORevisited,
                 WorkshopMods.PlopTheGrowables))
             {
                 Log.Info("The 'Real Time' mod will not change the building construction and upgrading behavior because some building mod is active.");

--- a/src/RealTime/Core/RealTimeCore.cs
+++ b/src/RealTime/Core/RealTimeCore.cs
@@ -326,7 +326,7 @@ namespace RealTime.Core
                 OutsideConnectionAIPatch.DummyTrafficProbability,
             };
 
-            if (compatibility.IsAnyModActive(WorkshopMods.CitizenLifecycleRebalance) || compatibility.IsAnyModActive(WorkshopMods.LifecycleRebalanceRevisited))
+            if (compatibility.IsAnyModActive(WorkshopMods.CitizenLifecycleRebalance, WorkshopMods.LifecycleRebalanceRevisited))
             {
                 Log.Info("The 'Real Time' mod will not change the citizens aging because a 'Lifecycle Rebalance' mod is active.");
             }

--- a/src/RealTime/Core/WorkshopMods.cs
+++ b/src/RealTime/Core/WorkshopMods.cs
@@ -47,5 +47,11 @@ namespace RealTime.Core
 
         /// <summary>The Workshop ID of the 'Real Time Offline' mod.</summary>
         public const ulong RealTimeOffline = 1749971558ul;
+        
+        /// <summary>The Workshop ID of the 'Ploppable RICO Revisited' mod.</summary>
+        public const ulong PloppableRICORevisited = 2016920607ul;
+
+        /// <summary>The Workshop ID of the 'Lifecycle Rebalance Revisited' mod.</summary>
+        public const ulong LifecycleRebalanceRevisited = 2027161563ul;
     }
 }


### PR DESCRIPTION
Suggesting the addition of checks for two new mods that are forked off earlier mods which already have compatibilty checks:

"[**Lifecycle Rebalance Revisited**](https://steamcommunity.com/sharedfiles/filedetails/?id=2027161563)", forked off (and official sucessor of) "Citizen Lifecycle Rebalance" - 

"[**Ploppable RICO Revisited**](https://steamcommunity.com/sharedfiles/filedetails/?id=2016920607)", forked off "Ploppable RICO". 

The changes just make these two 'Revisited' mods be detected and treated exactly the same as their parents.  Sorry for the bother!

Hoping to add some more formal integration/co-operation between these mods going forward, thinking most likely as a configuration setting within 'Lifecycle Rebalance', but that's for a later day.